### PR TITLE
New Dispatch Attribute

### DIFF
--- a/lib/scorm_cloud/dispatch.rb
+++ b/lib/scorm_cloud/dispatch.rb
@@ -2,7 +2,7 @@ module ScormCloud
   class Dispatch < ScormCloud::BaseObject
     attr_accessor :id, :destination_id, :app_id, :course_app_id, :course_id, :enabled, :notes, :open,
       :version, :tags, :created_by, :create_date, :update_date, :registrationcap, :registrationcount,
-      :instanced
+      :instanced, :expiration_date
 
     def self.from_xml(element)
       d = Dispatch.new


### PR DESCRIPTION
SCORM Engine provides a new expiration_date attribute for the getDispatchInfo call.
Added a new attr_accessor to fix the de-serialization from the API response.
